### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Atmel Corporation
 maintainer=Josh Datko <jbd@cryptotronix.com>
 sentence=Device driver library for the Atmel ATSHA204 and ATECC108
 paragraph=Implements a communication layer for applications to interface with the ATSHA204 and ATECC108;
+category=Device Control
 url=https://github.com/cryptotronix/cryptoauth-arduino
 architectures=avr


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library CryptoAuth is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.